### PR TITLE
feat: add rss feed link into pages

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -47,6 +47,12 @@ module.exports = {
             sizes: '16x16',
             href: '/assets/favicon/favicon-16x16.png'
         }],
+        ['link', {
+            rel: 'alternate',
+            type: 'application/rss+xml',
+            title: 'RSS',
+            href: '/rss.xml',
+        }],
     ],
 
     /**


### PR DESCRIPTION
hi,
this will add the link to generated rss feed into `<head>` of generated pags for easier discoverability via RSS readers

```
<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
```